### PR TITLE
Fix missing UART_TX/RX pins assigments on MIST

### DIFF
--- a/menu.sv
+++ b/menu.sv
@@ -471,4 +471,6 @@ assign HDMI_PCLK = clk_x2;
 
 `endif
 
+assign UART_TX = 1'bz;
+
 endmodule

--- a/mist/menu.qsf
+++ b/mist/menu.qsf
@@ -61,6 +61,8 @@ set_location_assignment PIN_136 -to VGA_VS
 set_location_assignment PIN_119 -to VGA_HS
 set_location_assignment PIN_65 -to AUDIO_L
 set_location_assignment PIN_80 -to AUDIO_R
+set_location_assignment PIN_46 -to UART_TX
+set_location_assignment PIN_31 -to UART_RX
 set_location_assignment PIN_105 -to SPI_DO
 set_location_assignment PIN_88 -to SPI_DI
 set_location_assignment PIN_126 -to SPI_SCK


### PR DESCRIPTION
For missing pins assigments Quartus randomly choose unused pins, which may lead to undesirable output levels conflict and even to pin damage in worst scenario.
I encountered this issue during debugging of ESP8266, which randomly hangs on reset. This fix completely eleminated esp issue.